### PR TITLE
Fix build with new sphinx

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -308,4 +308,4 @@ epub_copyright = '2013-2014, Brian Trammell'
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}


### PR DESCRIPTION
ERROR: Invalid value `None` in intersphinx_mapping['http://docs.python.org/']. Expected a two-element tuple or list.